### PR TITLE
Changes to improve Windows behavior, add options, and handle very large collections.  `python classify_mp3.py --help` for details

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ Then run the script
 python classify_mp3.py
 ```
 
+Options:
+```
+python classify_mp3.py --help
+usage: classify_mp3.py [-h] [-a] [-A] [-b] [-B] [-c] [-C] [-d] [-t] [-T] [-v] [-y] [-Y] [input_dir] [output_dir]
+
+Classify a Google Takeout collection of Google Music MP3 files, moving them to a directory tree in the output directory as '.../artist/(year) album/track -
+filename.mp3'.
+
+positional arguments:
+  input_dir             input directory containing files to classify, default is ../Takeout/Google Play Music/Tracks
+  output_dir            output directory, default is input directory
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -a, --artist          include the artist name as a layer in the directory tree
+  -A, --no-artist       do not include the artist name as a layer in the directory tree
+  -b, --album           include the album name as a layer in the directory tree
+  -B, --no-album        do not include the album name as a layer in the directory tree
+  -c, --remove-csvs     remove CSV files from the input directory
+  -C, --no-remove-csvs  do not remove CSV files from the input directory
+  -d, --dry-run         do not actually change files
+  -t, --track-number    include the track number in the filename
+  -T, --no-track-number
+                        do not include the track number in the filename
+  -v, --version         show program's version number and exit
+  -y, --year            include the year in the album directory name
+  -Y, --no-year         do not include the year in the album directory name
+
+Defaults: -a -b -T -Y
+```
+
 ## Others:
 * Don't hesitate to fix/improve/fork
 * Only tested on MacOS but seems working on Linux/Windows

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import re
+import sys
 
 logging.getLogger("eyed3").setLevel(logging.CRITICAL)
 
@@ -91,8 +92,16 @@ def rename_and_move_file(out_dir, mp3_path, dry_run=False):
 
     print(f"Moving {mp3_path} to {file_path}")
     if not dry_run:
-        pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
-        os.rename(mp3_path, file_path)
+        try:
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            print(f"Error {e.errno} creating {os.path.dirname(file_path)}: {e.strerror}", file=sys.stderr)
+            return
+        try:
+            os.rename(mp3_path, file_path)
+        except OSError as e:
+            print(f"Error {e.errno} moving {mp3_path} to {file_path}: {e.strerror}", file=sys.stderr)
+            return
 
 def remove_csv_files(input_dir, dry_run=False):
     print("Removing .csv files.")

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import re
 
-FILES_DIR = "../Takeout/Google Play Musique/Titres"
+FILES_DIR = "../Takeout/Google Play Music/Tracks"
 
 logging.getLogger("eyed3").setLevel(logging.CRITICAL)
 

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -46,8 +46,15 @@ def get_data_from_filename(file_path):
 
     return data
 
+def main():
+    for mp3_path in glob.glob(FILES_DIR + "/*.mp3"):
+        rename_and_move_file(mp3_path)
+    print("Sorting MP3 files done.")
 
-for mp3_path in glob.glob(FILES_DIR + "/*.mp3"):
+    remove_csv_files(FILES_DIR)
+    print("Script finished.")
+
+def rename_and_move_file(mp3_path):
     id3 = eyed3.load(mp3_path).tag
 
     filename_infos = get_data_from_filename(mp3_path)
@@ -86,12 +93,12 @@ for mp3_path in glob.glob(FILES_DIR + "/*.mp3"):
 
     print(f"{mp3_path} moved to {file_path}")
 
-print("Sorting MP3 files done.")
+def remove_csv_files(files_dir):
+    print("Removing .csv files.")
 
-print("Removing .csv file.")
+    for csv_path in glob.glob(files_dir + "/*.csv"):
+        print(f"Removing file {csv_path}")
+        os.remove(csv_path)
 
-for csv_path in glob.glob(FILES_DIR + "/*.csv"):
-    print(f"Removing file {csv_path}")
-    os.remove(csv_path)
-
-print("Script finishes")
+if __name__ == "__main__":
+    main()

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -75,10 +75,10 @@ def init_argparse():
         action="version", version = f"{parser.prog} version 1.0.0")
     parser.add_argument("-y", "--year",
         action="store_true", dest="year", default=False,
-        help="include the year as a layer in the directory tree")
+        help="include the year in the album directory name")
     parser.add_argument("-Y", "--no-year",
         action="store_false", dest="year",
-        help="do not include the year as a layer in the directory tree")
+        help="do not include the year in the album directory name")
     parser.add_argument("input_dir", nargs="?",
         default="../Takeout/Google Play Music/Tracks",
         help="input directory containing files to classify, default is %(default)s")

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -10,7 +10,7 @@ logging.getLogger("eyed3").setLevel(logging.CRITICAL)
 
 
 def get_data_from_filename(file_path):
-    file_name = file_path.split("/")[-1].replace(".mp3", "")
+    filename = os.path.basename(file_path)
     data = {
         "artist": "000 - unknown artist",
         "album": "000 - unknown album",
@@ -40,7 +40,7 @@ def get_data_from_filename(file_path):
     return data
 
 def init_argparse():
-    parser = argparse.ArgumentParser(description="Classify a Google Takeout collection of Google Music MP3 files, moving them to a directory tree in the output directory as '.../artist/year/album/track - filename.mp3'.")
+    parser = argparse.ArgumentParser(description="Classify a Google Takeout collection of Google Music MP3 files, moving them to a directory tree in the output directory as '.../artist/(year) album/track - filename.mp3'.")
     parser.add_argument("-d", "--dry-run",
         action="store_true", default=False,
         help="do not actually change files")
@@ -59,7 +59,7 @@ def main():
     if args.output_dir is None:
         args.output_dir = args.input_dir
 
-    for mp3_path in glob.glob(args.input_dir + "/*.mp3"):
+    for mp3_path in glob.glob(os.path.join(args.input_dir, "*.mp3")):
         rename_and_move_file(args.output_dir, mp3_path, dry_run=args.dry_run)
     print("Sorting MP3 files done.")
 
@@ -68,7 +68,6 @@ def main():
 
 def rename_and_move_file(out_dir, mp3_path, dry_run=False):
     id3 = eyed3.load(mp3_path).tag
-
     filename_infos = get_data_from_filename(mp3_path)
 
     artist = id3.artist or filename_infos.get("artist")
@@ -98,7 +97,7 @@ def rename_and_move_file(out_dir, mp3_path, dry_run=False):
 def remove_csv_files(input_dir, dry_run=False):
     print("Removing .csv files.")
 
-    for csv_path in glob.glob(input_dir + "/*.csv"):
+    for csv_path in glob.glob(os.path.join(input_dir, "*.csv")):
         print(f"Removing file {csv_path}")
         if not dry_run:
             os.remove(csv_path)

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import os
 import pathlib
+import platform
 import re
 import sys
 
@@ -83,17 +84,14 @@ def rename_and_move_file(out_dir, mp3_path, dry_run=False):
 
     album = (f"({year}) " if year is not None else "") + album
 
-    filename = f"{track_num[0]:02} - " if track_num is not None else ""
-    filename = f"{filename}{title}.mp3".replace(os.path.sep, "-")
+    filename = (f"{track_num[0]:02} - " if track_num is not None else "") + title
+    file_path = os.path.join(out_dir, remove_invalid_chars(artist), remove_invalid_chars(album), remove_invalid_chars(filename) + ".mp3")
 
-    # Create directories & file
-    dir_path = os.path.join(out_dir, artist, album)
-    file_path = os.path.join(dir_path, filename)
-
+    # Create directories & move file
     print(f"Moving {mp3_path} to {file_path}")
     if not dry_run:
         try:
-            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+            pathlib.Path(os.path.dirname(file_path)).mkdir(parents=True, exist_ok=True)
         except OSError as e:
             print(f"Error {e.errno} creating {os.path.dirname(file_path)}: {e.strerror}", file=sys.stderr)
             return
@@ -110,6 +108,12 @@ def remove_csv_files(input_dir, dry_run=False):
         print(f"Removing file {csv_path}")
         if not dry_run:
             os.remove(csv_path)
+
+def remove_invalid_chars(str):
+    invalid_chars = "/"
+    if platform.system() == "Windows":
+        invalid_chars = invalid_chars + ":\"\\?*"
+    return re.sub("[" + invalid_chars +"]", "-", str.rstrip())
 
 if __name__ == "__main__":
     main()

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -30,7 +30,7 @@ def get_data_from_filename(file_path):
     )
 
     for pattern in patterns:
-        result = pattern.search(file_name)
+        result = pattern.search(filename)
         if result is not None:
             data.update({
                 "album": result.group("album") if "album" in pattern.groupindex else None,
@@ -56,6 +56,12 @@ def init_argparse():
     parser.add_argument("-B", "--no-album",
         action="store_false", dest="album",
         help="do not include the album name as a layer in the directory tree")
+    parser.add_argument("-c", "--remove-csvs",
+        action="store_true", dest="remove_csvs", default=True,
+        help="remove CSV files from the input directory")
+    parser.add_argument("-C", "--no-remove-csvs",
+        action="store_false", dest="remove_csvs",
+        help="do not remove CSV files from the input directory")
     parser.add_argument("-d", "--dry-run",
         action="store_true", default=False,
         help="do not actually change files")
@@ -91,7 +97,8 @@ def main():
             add_album=args.album, add_year=args.year, add_track=args.track_number)
     print("Sorting MP3 files done.")
 
-    remove_csv_files(args.input_dir, dry_run=args.dry_run)
+    if args.remove_csvs:
+        remove_csv_files(args.input_dir, dry_run=args.dry_run)
     print("Script finished.")
 
 def rename_and_move_file(out_dir, mp3_path, dry_run=False, add_artist=True, add_album=True, add_year=False, add_track=False):

--- a/classify_mp3.py
+++ b/classify_mp3.py
@@ -92,7 +92,7 @@ def main():
     if args.output_dir is None:
         args.output_dir = args.input_dir
 
-    for mp3_path in glob.glob(os.path.join(args.input_dir, "*.mp3")):
+    for mp3_path in glob.iglob(os.path.join(args.input_dir, "*.mp3")):
         rename_and_move_file(args.output_dir, mp3_path, dry_run=args.dry_run, add_artist=args.artist,
             add_album=args.album, add_year=args.year, add_track=args.track_number)
     print("Sorting MP3 files done.")
@@ -146,7 +146,7 @@ def rename_and_move_file(out_dir, mp3_path, dry_run=False, add_artist=True, add_
 def remove_csv_files(input_dir, dry_run=False):
     print("Removing .csv files.")
 
-    for csv_path in glob.glob(os.path.join(input_dir, "*.csv")):
+    for csv_path in glob.iglob(os.path.join(input_dir, "*.csv")):
         print(f"Removing file {csv_path}")
         if not dry_run:
             os.remove(csv_path)


### PR DESCRIPTION
A bunch of changes that make this wonderful tool function better.

- Language independence: Apparently Google Takeout localizes the directory name.
- Make classify_mp3 run as a typical Python main program, with command-line arguments etc.
- Allow command-line specification of input and output directories, (output defaulting to same as input, as before).
- Use some Pythonic idioms to make the code cleaner and easier to read.
- Add a "dry run" option, to show what will happen without making any changes.
- Use Pythonic platform-difference API to control Windows vs. Mac differences.
- Report errors creating directories or moving files, and continue with other files.
- Remove invalid characters from file name directory names (Windows has several).
- Options to control construction of directory and file names (artist, album, year, track#).
- Option to remove or not remove CSV files.
- Handle really large collections by streaming the file list.
